### PR TITLE
Remove the name alias.

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -241,7 +241,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * `keys` property is pressed.
      *
      * @demo demo/index.html
-     * @polymerBehavior IronA11yKeysBehavior
+     * @polymerBehavior
      */
     Polymer.IronA11yKeysBehavior = {
       properties: {


### PR DESCRIPTION
This was breaking catalog linking by saving the behavior as "IronA11KeysBehavior" instead of "Polymer.IronA11yKeysBehavior"