### PR TITLE
Enable selective automatic stop propagation.

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -255,6 +255,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         },
 
+        /**
+         * If true, this property will cause the implementing element to
+         * automatically stop propagation on any handled KeyboardEvents.
+         */
+        stopKeyboardEventPropagation: {
+          type: Boolean,
+          value: false
+        },
+
         _boundKeyHandlers: {
           type: Array,
           value: function() {
@@ -398,6 +407,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _onKeyBindingEvent: function(keyBindings, event) {
+        if (this.stopKeyboardEventPropagation) {
+          event.stopPropagation();
+        }
+
         keyBindings.forEach(function(keyBinding) {
           var keyCombo = keyBinding[0];
           var handlerName = keyBinding[1];

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -30,6 +30,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NonPropagatingKeys">
+    <template>
+      <x-a11y-basic-keys stop-keyboard-event-propagation></x-a11y-basic-keys>
+    </template>
+  </test-fixture>
+
   <test-fixture id="ComboKeys">
     <template>
       <x-a11y-combo-keys></x-a11y-combo-keys>
@@ -161,6 +167,15 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       expect(keys.keyCount).to.be.equal(1);
     });
 
+    test('allows propagation beyond the key combo handler', function() {
+      var keySpy = sinon.spy();
+      document.addEventListener('keydown', keySpy);
+
+      MockInteractions.pressEnter(keys);
+
+      expect(keySpy.callCount).to.be.equal(1);
+    });
+
     suite('edge cases', function() {
       test('knows that `spacebar` is the same as `space`', function() {
         var event = new CustomEvent('keydown');
@@ -239,6 +254,22 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       MockInteractions.pressSpace(keys);
 
       expect(keys.keyCount).to.be.equal(2);
+    });
+  });
+
+  suite('stopping propagation automatically', function() {
+    setup(function() {
+      keys = fixture('NonPropagatingKeys');
+    });
+
+    test('does not propagate key events beyond the combo handler', function() {
+      var keySpy = sinon.spy();
+
+      document.addEventListener('keydown', keySpy);
+
+      MockInteractions.pressEnter(keys);
+
+      expect(keySpy.callCount).to.be.equal(0);
     });
   });
 


### PR DESCRIPTION
This is supported now via a `stop-keyboard-event-propagation` boolean
attribute on any implementing elements.

Fixes #17