### PR TITLE
srcEvent.preventDefault when CustomEvent.preventDefault is called

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -424,10 +424,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _triggerKeyHandler: function(keyCombo, handlerName, keyboardEvent) {
         var detail = Object.create(keyCombo);
         detail.keyboardEvent = keyboardEvent;
-
-        this[handlerName].call(this, new CustomEvent(keyCombo.event, {
-          detail: detail
-        }));
+        var event = new CustomEvent(keyCombo.event, {
+          detail: detail,
+          cancelable: true
+        });
+        this[handlerName].call(this, event);
+        if (event.defaultPrevented) {
+          keyboardEvent.preventDefault();
+        }
       }
     };
   })();

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -70,6 +70,9 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       _keyHandler: function(event) {
         this.keyCount++;
         this.lastEvent = event;
+      },
+      _preventDefaultHandler: function(event) {
+        event.preventDefault();
       }
     }];
 
@@ -124,7 +127,8 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       ],
 
       keyBindings: {
-        'space': '_keyHandler'
+        'space': '_keyHandler',
+        'enter': '_preventDefaultHandler'
       }
     });
   });
@@ -270,6 +274,21 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       MockInteractions.pressEnter(keys);
 
       expect(keySpy.callCount).to.be.equal(0);
+    });
+  });
+
+  suite('prevent default behavior of event', function() {
+    setup(function() {
+      keys = fixture('BehaviorKeys');
+    });
+    test('defaultPrevented is correctly set', function() {
+      var keySpy = sinon.spy();
+
+      document.addEventListener('keydown', keySpy);
+
+      MockInteractions.pressEnter(keys);
+
+      expect(keySpy.getCall(0).args[0].defaultPrevented).to.be.equal(true);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-a11y-keys-behavior/issues/13

We call preventDefault for source event when CustomEvent has defaultPrevented.
Depends on https://github.com/PolymerElements/iron-test-helpers/pull/25