### PR TITLE
support special symbols

### DIFF
--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -37,6 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
   <template>
     <h4>Press any of these keys</h4>
+    <input type="checkbox" checked="{{preventDefault::change}}"> prevent default = {{preventDefault}}
     <p class="keys">
       <template is="dom-repeat" items="[[boundKeys]]">
         <span>{{item}}</span>
@@ -68,6 +69,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      preventDefault: {
+        type: Boolean,
+        value: true,
+        notify: true
+      },
+
       keyEventTarget: {
         type: Object,
         value: function() {
@@ -77,12 +84,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     keyBindings: {
-      '* pageup pagedown left right down up shift+a alt+a home end space enter': '_updatePressed'
+      '* pageup pagedown left right down up home end space enter @ ~ " $ ? ! \\ + : # backspace': '_updatePressed',
+      'a': '_updatePressed',
+      'shift+a alt+a': '_updatePressed'
     },
 
     _updatePressed: function(event) {
       console.log(event.detail);
 
+      if (this.preventDefault) {
+        event.preventDefault();
+      }
       this._setPressed(
         this.pressed + event.detail.combo + ' pressed!\n'
       );

--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -21,46 +21,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Values taken from: http://www.w3.org/TR/2007/WD-DOM-Level-3-Events-20071221/keyset.html#KeySet-Set
      */
     var KEY_IDENTIFIER = {
+      'U+0008': 'backspace',
       'U+0009': 'tab',
       'U+001B': 'esc',
       'U+0020': 'space',
-      'U+002A': '*',
-      'U+0030': '0',
-      'U+0031': '1',
-      'U+0032': '2',
-      'U+0033': '3',
-      'U+0034': '4',
-      'U+0035': '5',
-      'U+0036': '6',
-      'U+0037': '7',
-      'U+0038': '8',
-      'U+0039': '9',
-      'U+0041': 'a',
-      'U+0042': 'b',
-      'U+0043': 'c',
-      'U+0044': 'd',
-      'U+0045': 'e',
-      'U+0046': 'f',
-      'U+0047': 'g',
-      'U+0048': 'h',
-      'U+0049': 'i',
-      'U+004A': 'j',
-      'U+004B': 'k',
-      'U+004C': 'l',
-      'U+004D': 'm',
-      'U+004E': 'n',
-      'U+004F': 'o',
-      'U+0050': 'p',
-      'U+0051': 'q',
-      'U+0052': 'r',
-      'U+0053': 's',
-      'U+0054': 't',
-      'U+0055': 'u',
-      'U+0056': 'v',
-      'U+0057': 'w',
-      'U+0058': 'x',
-      'U+0059': 'y',
-      'U+005A': 'z',
       'U+007F': 'del'
     };
 
@@ -72,6 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Values from: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent.keyCode#Value_of_keyCode
      */
     var KEY_CODE = {
+      8: 'backspace',
       9: 'tab',
       13: 'enter',
       27: 'esc',
@@ -101,16 +66,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
 
     /**
-     * KeyboardEvent.key is mostly represented by printable character made by
-     * the keyboard, with unprintable keys labeled nicely.
-     *
-     * However, on OS X, Alt+char can make a Unicode character that follows an
-     * Apple-specific mapping. In this case, we
-     * fall back to .keyCode.
-     */
-    var KEY_CHAR = /[a-z0-9*]/;
-
-    /**
      * Matches a keyIdentifier string.
      */
     var IDENT_CHAR = /U\+/;
@@ -130,14 +85,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var validKey = '';
       if (key) {
         var lKey = key.toLowerCase();
-        if (lKey.length == 1) {
-          if (KEY_CHAR.test(lKey)) {
-            validKey = lKey;
-          }
+        if (lKey === ' ' || SPACE_KEY.test(lKey)) {
+          validKey = 'space';
+        } else if (lKey.length == 1) {
+          validKey = lKey;
         } else if (ARROW_KEY.test(lKey)) {
           validKey = lKey.replace('arrow', '');
-        } else if (SPACE_KEY.test(lKey)) {
-          validKey = 'space';
         } else if (lKey == 'multiply') {
           // numpad '*' can map to Multiply on IE/Windows
           validKey = '*';
@@ -151,8 +104,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     function transformKeyIdentifier(keyIdent) {
       var validKey = '';
       if (keyIdent) {
-        if (IDENT_CHAR.test(keyIdent)) {
+        if (keyIdent in KEY_IDENTIFIER) {
           validKey = KEY_IDENTIFIER[keyIdent];
+        } else if (IDENT_CHAR.test(keyIdent)) {
+          keyIdent = parseInt(keyIdent.replace('U+', '0x'), 16);
+          validKey = String.fromCharCode(keyIdent).toLowerCase();
         } else {
           validKey = keyIdent.toLowerCase();
         }
@@ -192,15 +148,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         transformKey(keyEvent.detail.key) || '';
     }
 
-    function keyComboMatchesEvent(keyCombo, keyEvent) {
-      return normalizedKeyForEvent(keyEvent) === keyCombo.key &&
-        !!keyEvent.shiftKey === !!keyCombo.shiftKey &&
-        !!keyEvent.ctrlKey === !!keyCombo.ctrlKey &&
-        !!keyEvent.altKey === !!keyCombo.altKey &&
-        !!keyEvent.metaKey === !!keyCombo.metaKey;
+    function keyComboMatchesEvent(keyCombo, event, eventKey) {
+      return eventKey === keyCombo.key &&
+        (!keyCombo.hasModifiers || (
+          !!event.shiftKey === !!keyCombo.shiftKey &&
+          !!event.ctrlKey === !!keyCombo.ctrlKey &&
+          !!event.altKey === !!keyCombo.altKey &&
+          !!event.metaKey === !!keyCombo.metaKey)
+        );
     }
 
     function parseKeyComboString(keyComboString) {
+      if (keyComboString.length === 1) {
+        return {
+          combo: keyComboString,
+          key: keyComboString,
+          event: 'keydown'
+        };
+      }
       return keyComboString.split('+').reduce(function(parsedKeyCombo, keyComboPart) {
         var eventParts = keyComboPart.split(':');
         var keyName = eventParts[0];
@@ -208,6 +173,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         if (keyName in MODIFIER_KEYS) {
           parsedKeyCombo[MODIFIER_KEYS[keyName]] = true;
+          parsedKeyCombo.hasModifiers = true;
         } else {
           parsedKeyCombo.key = keyName;
           parsedKeyCombo.event = event || 'keydown';
@@ -220,11 +186,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function parseEventString(eventString) {
-      return eventString.split(' ').map(function(keyComboString) {
+      return eventString.trim().split(' ').map(function(keyComboString) {
         return parseKeyComboString(keyComboString);
       });
     }
-
 
     /**
      * `Polymer.IronA11yKeysBehavior` provides a normalized interface for processing
@@ -321,14 +286,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       keyboardEventMatchesKeys: function(event, eventString) {
         var keyCombos = parseEventString(eventString);
-        var index;
-
-        for (index = 0; index < keyCombos.length; ++index) {
-          if (keyComboMatchesEvent(keyCombos[index], event)) {
+        var eventKey = normalizedKeyForEvent(event);
+        for (var i = 0; i < keyCombos.length; ++i) {
+          if (keyComboMatchesEvent(keyCombos[i], event, eventKey)) {
             return true;
           }
         }
-
         return false;
       },
 
@@ -355,6 +318,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         for (var eventString in this._imperativeKeyBindings) {
           this._addKeyBinding(eventString, this._imperativeKeyBindings[eventString]);
+        }
+
+        // Give precedence to combos with modifiers to be checked first.
+        for (var eventName in this._keyBindings) {
+          this._keyBindings[eventName].sort(function (kb1, kb2) {
+            var b1 = kb1[0].hasModifiers;
+            var b2 = kb2[0].hasModifiers;
+            return (b1 === b2) ? 0 : b1 ? -1 : 1;
+          })
         }
       },
 
@@ -411,14 +383,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           event.stopPropagation();
         }
 
-        keyBindings.forEach(function(keyBinding) {
-          var keyCombo = keyBinding[0];
-          var handlerName = keyBinding[1];
+        // if event has been already prevented, don't do anything
+        if (event.defaultPrevented) {
+          return;
+        }
 
-          if (!event.defaultPrevented && keyComboMatchesEvent(keyCombo, event)) {
+        var eventKey = normalizedKeyForEvent(event);
+        for (var i = 0; i < keyBindings.length; i++) {
+          var keyCombo = keyBindings[i][0];
+          var handlerName = keyBindings[i][1];
+          if (keyComboMatchesEvent(keyCombo, event, eventKey)) {
             this._triggerKeyHandler(keyCombo, handlerName, event);
+            // exit the loop if eventDefault was prevented
+            if (event.defaultPrevented) {
+              return;
+            }
           }
-        }, this);
+        }
       },
 
       _triggerKeyHandler: function(keyCombo, handlerName, keyboardEvent) {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -52,6 +52,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="PreventKeys">
+    <template>
+      <x-a11y-prevent-keys></x-a11y-prevent-keys>
+    </template>
+  </test-fixture>
+
   <script>
 suite('Polymer.IronA11yKeysBehavior', function() {
   var keys;
@@ -69,8 +75,17 @@ suite('Polymer.IronA11yKeysBehavior', function() {
         this.keyCount++;
         this.lastEvent = event;
       },
+
+      // Same as _keyHandler, used to distinguish who's called before who.
+      _keyHandler2: function(event) {
+        this.keyCount++;
+        this.lastEvent = event;
+      },
+
       _preventDefaultHandler: function(event) {
         event.preventDefault();
+        this.keyCount++;
+        this.lastEvent = event;
       }
     }];
 
@@ -94,7 +109,8 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       ],
 
       keyBindings: {
-        'ctrl+shift+a': '_keyHandler'
+        'enter': '_keyHandler2',
+        'ctrl+shift+a shift+enter': '_keyHandler'
       }
     });
 
@@ -125,8 +141,21 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       ],
 
       keyBindings: {
-        'space': '_keyHandler',
-        'enter': '_preventDefaultHandler'
+        'enter': '_keyHandler'
+      }
+    });
+
+    Polymer({
+      is: 'x-a11y-prevent-keys',
+
+      behaviors: [
+        KeysTestBehavior,
+        XA11yBehavior
+      ],
+
+      keyBindings: {
+        'space a': '_keyHandler',
+        'enter shift+a': '_preventDefaultHandler'
       }
     });
   });
@@ -139,6 +168,14 @@ suite('Polymer.IronA11yKeysBehavior', function() {
     test('trigger the handler when the specified key is pressed', function() {
       MockInteractions.pressSpace(keys);
 
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('trigger the handler when the specified key is pressed together with a modifier', function() {
+      var event = new CustomEvent('keydown');
+      event.ctrlKey = true;
+      event.keyCode = event.code = 32;
+      keys.dispatchEvent(event);
       expect(keys.keyCount).to.be.equal(1);
     });
 
@@ -182,6 +219,24 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       test('knows that `spacebar` is the same as `space`', function() {
         var event = new CustomEvent('keydown');
         event.key = 'spacebar';
+        expect(keys.keyboardEventMatchesKeys(event, 'space')).to.be.equal(true);
+      });
+
+      test('handles `+`', function() {
+        var event = new CustomEvent('keydown');
+        event.key = '+';
+        expect(keys.keyboardEventMatchesKeys(event, '+')).to.be.equal(true);
+      });
+
+      test('handles `:`', function() {
+        var event = new CustomEvent('keydown');
+        event.key = ':';
+        expect(keys.keyboardEventMatchesKeys(event, ':')).to.be.equal(true);
+      });
+
+      test('handles ` ` (space)', function() {
+        var event = new CustomEvent('keydown');
+        event.key = ' ';
         expect(keys.keyboardEventMatchesKeys(event, 'space')).to.be.equal(true);
       });
     });
@@ -228,6 +283,28 @@ suite('Polymer.IronA11yKeysBehavior', function() {
 
       expect(keys.keyCount).to.be.equal(1);
     });
+
+    test('trigger also bindings without modifiers', function() {
+      var event = new CustomEvent('keydown');
+      // Combo `shift+enter`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 13;
+      keys.dispatchEvent(event);
+      expect(keys.keyCount).to.be.equal(2);
+    });
+
+    test('give precendence to combos with modifiers', function() {
+      var enterSpy = sinon.spy(keys, '_keyHandler2');
+      var shiftEnterSpy = sinon.spy(keys, '_keyHandler');
+      var event = new CustomEvent('keydown');
+      // Combo `shift+enter`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 13;
+      keys.dispatchEvent(event);
+      expect(enterSpy.called).to.be.true;
+      expect(shiftEnterSpy.called).to.be.true;
+      expect(enterSpy.calledAfter(shiftEnterSpy)).to.be.true;
+    });
   });
 
   suite('alternative event keys', function() {
@@ -253,8 +330,6 @@ suite('Polymer.IronA11yKeysBehavior', function() {
 
     test('bindings in other behaviors are transitive', function() {
       MockInteractions.pressEnter(keys);
-      MockInteractions.pressSpace(keys);
-
       expect(keys.keyCount).to.be.equal(2);
     });
   });
@@ -277,16 +352,28 @@ suite('Polymer.IronA11yKeysBehavior', function() {
 
   suite('prevent default behavior of event', function() {
     setup(function() {
-      keys = fixture('BehaviorKeys');
+      keys = fixture('PreventKeys');
     });
-    test('defaultPrevented is correctly set', function() {
-      var keySpy = sinon.spy();
 
-      document.addEventListener('keydown', keySpy);
-
+    test('`defaultPrevented` is correctly set', function() {
       MockInteractions.pressEnter(keys);
+      expect(keys.lastEvent.defaultPrevented).to.be.equal(true);
+    });
 
-      expect(keySpy.getCall(0).args[0].defaultPrevented).to.be.equal(true);
+    test('only 1 handler is invoked', function() {
+      var aSpy = sinon.spy(keys, '_keyHandler');
+      var shiftASpy = sinon.spy(keys, '_preventDefaultHandler');
+      var event = new CustomEvent('keydown', {
+        cancelable: true
+      });
+      // Combo `shift+a`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 65;
+      keys.dispatchEvent(event);
+
+      expect(keys.keyCount).to.be.equal(1);
+      expect(shiftASpy.called).to.be.true;
+      expect(aSpy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
Fixes #12 by adding support for special symbols

- [x] Handle special characters like `@ # !` etc...  by relying on `event.key` (ff/ie) and `event.keyIdentifier` + `String.fromCharCode` (chrome/safari).
- [x] Special handling for `+` and `:` since they're used as separators for combo keys.
- [x] Allow shift/ctrl/meta key combination usage by default (e.g. "a pressed!" triggered if user presses or `a` or `shift+a`) 
- [x] unit tests for modifier keys combination by default
- [x] unit tests for these special characters: space ( ), plus (+), colon (:)

Limitations: 
- listeners to combos like `alt+@` are not supported (since it depends on the keyboard configuration)
- on browsers that don't support [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) (e.g. chrome/safari), all keyboard events that have `keyIdentifier = "Unidentified"` won't be recognized; e.g. on a french keyboard, this key combination used for typing `@` has `keyIdentifier = "Unidentified"`
<img width="636" alt="screen shot 2015-11-13 at 10 59 17 am" src="https://cloud.githubusercontent.com/assets/6173664/11154839/99e1520c-89f6-11e5-97fa-172ed69bcb05.png">