### PR TITLE
support only alpha-numeric chars for combos

### DIFF
--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -86,7 +86,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     keyBindings: {
       '* pageup pagedown left right down up home end space enter @ ~ " $ ? ! \\ + : # backspace': '_updatePressed',
       'a': '_updatePressed',
-      'shift+a alt+a': '_updatePressed'
+      'shift+a alt+a': '_updatePressed',
+      'shift+tab shift+space': '_updatePressed'
     },
 
     _updatePressed: function(event) {

--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -66,6 +66,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
 
     /**
+     * KeyboardEvent.key is mostly represented by printable character made by
+     * the keyboard, with unprintable keys labeled nicely.
+     *
+     * However, on OS X, Alt+char can make a Unicode character that follows an
+     * Apple-specific mapping. In this case, we fall back to .keyCode.
+     */
+    var KEY_CHAR = /[a-z0-9*]/;
+
+    /**
      * Matches a keyIdentifier string.
      */
     var IDENT_CHAR = /U\+/;
@@ -81,14 +90,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     var SPACE_KEY = /^space(bar)?/;
 
-    function transformKey(key) {
+    /**
+     * Transforms the key.
+     * @param {string} key The KeyBoardEvent.key
+     * @param {Boolean} [noSpecialChars] Limits the transformation to
+     * alpha-numeric characters.
+     */
+    function transformKey(key, noSpecialChars) {
       var validKey = '';
       if (key) {
         var lKey = key.toLowerCase();
         if (lKey === ' ' || SPACE_KEY.test(lKey)) {
           validKey = 'space';
         } else if (lKey.length == 1) {
-          validKey = lKey;
+          if (!noSpecialChars || KEY_CHAR.test(lKey)) {
+            validKey = lKey;
+          }
         } else if (ARROW_KEY.test(lKey)) {
           validKey = lKey.replace('arrow', '');
         } else if (lKey == 'multiply') {
@@ -139,17 +156,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return validKey;
     }
 
-    function normalizedKeyForEvent(keyEvent) {
-      // fall back from .key, to .keyIdentifier, to .keyCode, and then to
-      // .detail.key to support artificial keyboard events
-      return transformKey(keyEvent.key) ||
+    /**
+      * Calculates the normalized key for a KeyboardEvent.
+      * @param {KeyboardEvent} keyEvent
+      * @param {Boolean} [noSpecialChars] Set to true to limit keyEvent.key
+      * transformation to alpha-numeric chars. This is useful with key
+      * combinations like shift + 2, which on FF for MacOS produces
+      * keyEvent.key = @
+      * To get 2 returned, set noSpecialChars = true
+      * To get @ returned, set noSpecialChars = false
+     */
+    function normalizedKeyForEvent(keyEvent, noSpecialChars) {
+      // Fall back from .key, to .keyIdentifier, to .keyCode, and then to
+      // .detail.key to support artificial keyboard events.
+      return transformKey(keyEvent.key, noSpecialChars) ||
         transformKeyIdentifier(keyEvent.keyIdentifier) ||
         transformKeyCode(keyEvent.keyCode) ||
-        transformKey(keyEvent.detail.key) || '';
+        transformKey(keyEvent.detail.key, noSpecialChars) || '';
     }
 
-    function keyComboMatchesEvent(keyCombo, event, eventKey) {
-      return eventKey === keyCombo.key &&
+    function keyComboMatchesEvent(keyCombo, event) {
+      // For combos with modifiers we support only alpha-numeric keys
+      var keyEvent = normalizedKeyForEvent(event, keyCombo.hasModifiers);
+      return keyEvent === keyCombo.key &&
         (!keyCombo.hasModifiers || (
           !!event.shiftKey === !!keyCombo.shiftKey &&
           !!event.ctrlKey === !!keyCombo.ctrlKey &&
@@ -286,9 +315,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       keyboardEventMatchesKeys: function(event, eventString) {
         var keyCombos = parseEventString(eventString);
-        var eventKey = normalizedKeyForEvent(event);
         for (var i = 0; i < keyCombos.length; ++i) {
-          if (keyComboMatchesEvent(keyCombos[i], event, eventKey)) {
+          if (keyComboMatchesEvent(keyCombos[i], event)) {
             return true;
           }
         }
@@ -388,11 +416,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return;
         }
 
-        var eventKey = normalizedKeyForEvent(event);
         for (var i = 0; i < keyBindings.length; i++) {
           var keyCombo = keyBindings[i][0];
           var handlerName = keyBindings[i][1];
-          if (keyComboMatchesEvent(keyCombo, event, eventKey)) {
+          if (keyComboMatchesEvent(keyCombo, event)) {
             this._triggerKeyHandler(keyCombo, handlerName, event);
             // exit the loop if eventDefault was prevented
             if (event.defaultPrevented) {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -97,7 +97,8 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       ],
 
       keyBindings: {
-        'space': '_keyHandler'
+        'space': '_keyHandler',
+        '@': '_keyHandler'
       }
     });
 
@@ -175,6 +176,13 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       var event = new CustomEvent('keydown');
       event.ctrlKey = true;
       event.keyCode = event.code = 32;
+      keys.dispatchEvent(event);
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('handles special character @', function() {
+      var event = new CustomEvent('keydown');
+      event.key = '@';
       keys.dispatchEvent(event);
       expect(keys.keyCount).to.be.equal(1);
     });
@@ -284,6 +292,19 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       expect(keys.keyCount).to.be.equal(1);
     });
 
+    test('check if KeyBoardEvent.key is alpha-numberic', function() {
+      var event = new CustomEvent('keydown');
+
+      event.ctrlKey = true;
+      event.shiftKey = true;
+      event.key = 'å';
+      event.keyCode = event.code = 65;
+
+      keys.dispatchEvent(event);
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
     test('trigger also bindings without modifiers', function() {
       var event = new CustomEvent('keydown');
       // Combo `shift+enter`.
@@ -305,6 +326,7 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       expect(shiftEnterSpy.called).to.be.true;
       expect(enterSpy.calledAfter(shiftEnterSpy)).to.be.true;
     });
+
   });
 
   suite('alternative event keys', function() {


### PR DESCRIPTION
Fixes #28 by supporting only alpha-numeric chars for combos.
Special characters recognition is still supported, but not with combos.