### PR TITLE
Fixed issue with reading number pad digits

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -128,14 +128,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           validKey = 'f' + (keyCode - 112);
         } else if (keyCode >= 48 && keyCode <= 57) {
           // top 0-9 keys
-          validKey = String(48 - keyCode);
+          validKey = String(keyCode - 48);
         } else if (keyCode >= 96 && keyCode <= 105) {
           // num pad 0-9
-          validKey = String(96 - keyCode);
+          validKey = String(keyCode - 96);
         } else {
           validKey = KEY_CODE[keyCode];
         }
       }
+      
       return validKey;
     }
 
@@ -143,8 +144,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // fall back from .key, to .keyIdentifier, to .keyCode, and then to
       // .detail.key to support artificial keyboard events
       return transformKey(keyEvent.key) ||
-        transformKeyIdentifier(keyEvent.keyIdentifier) ||
         transformKeyCode(keyEvent.keyCode) ||
+        transformKeyIdentifier(keyEvent.keyIdentifier) ||
         transformKey(keyEvent.detail.key) || '';
     }
 

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -265,6 +265,20 @@ suite('Polymer.IronA11yKeysBehavior', function() {
         expect(keys.keyboardEventMatchesKeys(event, 'up')).to.be.equal(true);
       });
     });
+    
+    suite('matching keyboard events to top row and number pad digit keys', function() {
+      test('top row can be done imperatively', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 49;
+        expect(keys.keyboardEventMatchesKeys(event, '1')).to.be.equal(true);
+      });
+      
+      test('number pad digits can be done imperatively', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 97;
+        expect(keys.keyboardEventMatchesKeys(event, '1')).to.be.equal(true);
+      });
+    });
   });
 
   suite('combo keys', function() {


### PR DESCRIPTION
This fixes #30 by moving the `transformKeyIdentifier` check and changing the way `transformKeyCode` transforms numeric keys.