### PR TITLE
handle keyEventTarget = null

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -249,7 +249,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer.IronA11yKeysBehavior = {
       properties: {
         /**
-         * The HTMLElement that will be firing relevant KeyboardEvents.
+         * The EventTarget that will be firing relevant KeyboardEvents. Set it to
+         * `null` to disable the listeners.
+         * @type {?EventTarget}
          */
         keyEventTarget: {
           type: Object,
@@ -389,7 +391,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _resetKeyEventListeners: function() {
         this._unlistenKeyEventListeners();
 
-        if (this.isAttached) {
+        if (this.isAttached && this.keyEventTarget) {
           this._listenKeyEventListeners();
         }
       },

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -173,6 +173,13 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       expect(keys.keyCount).to.be.equal(1);
     });
 
+    test('keyEventTarget can be null, and disables listeners', function() {
+      keys.keyEventTarget = null;
+      MockInteractions.pressSpace(keys);
+
+      expect(keys.keyCount).to.be.equal(0);
+    });
+
     test('trigger the handler when the specified key is pressed together with a modifier', function() {
       var event = new CustomEvent('keydown');
       event.ctrlKey = true;


### PR DESCRIPTION
Fixes #46 by handling `null` as valid value for `keyEventTarget`. Currently this creates problems in other components, e.g. https://github.com/PolymerElements/paper-ripple/issues/82