### PR TITLE
guard against null keyEventTarget

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -297,9 +297,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       attached: function() {
-        if (this.keyEventTarget) {
-          this._listenKeyEventListeners();
-        }
+        this._listenKeyEventListeners();
       },
 
       detached: function() {
@@ -393,12 +391,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       _resetKeyEventListeners: function() {
         this._unlistenKeyEventListeners();
 
-        if (this.isAttached && this.keyEventTarget) {
+        if (this.isAttached) {
           this._listenKeyEventListeners();
         }
       },
 
       _listenKeyEventListeners: function() {
+        if (!this.keyEventTarget) {
+          return;
+        }
         Object.keys(this._keyBindings).forEach(function(eventName) {
           var keyBindings = this._keyBindings[eventName];
           var boundKeyHandler = this._onKeyBindingEvent.bind(this, keyBindings);

--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -297,7 +297,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       attached: function() {
-        this._listenKeyEventListeners();
+        if (this.keyEventTarget) {
+          this._listenKeyEventListeners();
+        }
       },
 
       detached: function() {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -58,12 +58,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
-  <test-fixture id="NoIronA11yKeysBehavior">
-    <template>
-      <div></div>
-    </template>
-  </test-fixture>
-
   <script>
 suite('Polymer.IronA11yKeysBehavior', function() {
   var keys;
@@ -438,14 +432,11 @@ suite('Polymer.IronA11yKeysBehavior', function() {
   });
 
   suite('remove key behavior with null target', function () {
-    setup(function () {
-      container = fixture('NoIronA11yKeysBehavior');
-    });
-    test('add and remove a iron-a11y-keys-behavior', function (done) {
+    test('add and remove a iron-a11y-keys-behavior', function () {
       var element = document.createElement('x-a11y-basic-keys');
       element.keyEventTarget = null;
-      Polymer.dom(container).appendChild(element);
-      done();
+      document.body.appendChild(element);
+      document.body.removeChild(element);
     });
   });
 

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -447,7 +447,6 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       Polymer.dom(container).appendChild(element);
       done();
     });
-    
   });
 
 });

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -58,6 +58,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NoIronA11yKeysBehavior">
+    <template>
+      <div></div>
+    </template>
+  </test-fixture>
+
   <script>
 suite('Polymer.IronA11yKeysBehavior', function() {
   var keys;
@@ -429,6 +435,19 @@ suite('Polymer.IronA11yKeysBehavior', function() {
       expect(shiftASpy.called).to.be.true;
       expect(aSpy.called).to.be.false;
     });
+  });
+
+  suite('remove key behavior with null target', function () {
+    setup(function () {
+      container = fixture('NoIronA11yKeysBehavior');
+    });
+    test('add and remove a iron-a11y-keys-behavior', function (done) {
+      var element = document.createElement('x-a11y-basic-keys');
+      element.keyEventTarget = null;
+      Polymer.dom(container).appendChild(element);
+      done();
+    });
+    
   });
 
 });


### PR DESCRIPTION
There are two calls to _listenKeyEventListeners() and one already guards against  null this.keyEventTarget. This change guards the call to _listenKeyEventListeners in attached from using a null keyEventTarget.