### PR TITLE
Update keyBindings annotation

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -313,7 +313,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * To be used to express what combination of keys  will trigger the relative
        * callback. e.g. `keyBindings: { 'esc': '_onEscPressed'}`
-       * @type {Object}
+       * @type {!Object}
        */
       keyBindings: {},
 


### PR DESCRIPTION
`keyBindings` must always be defined, cannot be null/undefined
@notwaldorf PTAL