### PR TITLE
prefer key to deprecated keyIdentifier and keyCode

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -176,12 +176,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       * To get @ returned, set noSpecialChars = false
      */
     function normalizedKeyForEvent(keyEvent, noSpecialChars) {
-      // Fall back from .key, to .keyIdentifier, to .keyCode, and then to
-      // .detail.key to support artificial keyboard events.
-      return transformKey(keyEvent.key, noSpecialChars) ||
-        transformKeyIdentifier(keyEvent.keyIdentifier) ||
-        transformKeyCode(keyEvent.keyCode) ||
-        transformKey(keyEvent.detail ? keyEvent.detail.key : keyEvent.detail, noSpecialChars) || '';
+      // Fall back from .key, to .detail.key for artifical keyboard events,
+      // and then to deprecated .keyIdentifier and .keyCode.
+      if (keyEvent.key) {
+        return transformKey(keyEvent.key, noSpecialChars);
+      }
+      if (keyEvent.detail && keyEvent.detail.key) {
+        return transformKey(keyEvent.detail.key, noSpecialChars);
+      }
+      return transformKeyIdentifier(keyEvent.keyIdentifier) ||
+        transformKeyCode(keyEvent.keyCode) || '';
     }
 
     function keyComboMatchesEvent(keyCombo, event) {

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -329,8 +329,7 @@ suite('Polymer.IronA11yKeysBehavior', function() {
 
       event.ctrlKey = true;
       event.shiftKey = true;
-      event.key = 'å';
-      event.keyCode = event.code = 65;
+      event.key = 'A';
 
       keys.dispatchEvent(event);
 


### PR DESCRIPTION
Fixes #53, if `key` is defined in the event or artificially generated event (`detail.key`), we prefer that over `keyIdentifier` or `keyCode`.
I've updated the test to actually check for the result of `shift + ctrl + a` which gives `event.key = 'A'`, and purposely removed `keyCode, code` settings to mimic the ideal, future keyboard event which will have only `key` set.