### PR TITLE
Update iron-a11y-keys-behavior.html

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -321,7 +321,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       keyBindings: {},
 
-      registered: function() {
+      created: function() {
         this._prepKeyBindings();
       },
 


### PR DESCRIPTION
Fixes an issue with `paper-input`:

![error](https://i.imgur.com/uoFNgFg.png)
