### PR TITLE
Handle function keys without key property correctly

### DIFF
--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -151,7 +151,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           validKey = String.fromCharCode(32 + keyCode);
         } else if (keyCode >= 112 && keyCode <= 123) {
           // function keys f1-f12
-          validKey = 'f' + (keyCode - 112);
+          validKey = 'f' + (keyCode - 112 + 1);
         } else if (keyCode >= 48 && keyCode <= 57) {
           // top 0-9 keys
           validKey = String(keyCode - 48);

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -292,6 +292,14 @@ suite('Polymer.IronA11yKeysBehavior', function() {
         event.key = 'ArrowUp';
         expect(keys.keyboardEventMatchesKeys(event, 'up')).to.be.equal(true);
       });
+
+      test('can handle function keys', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 112;
+        expect(keys.keyboardEventMatchesKeys(event, 'f1')).to.be.equal(true);
+        event.keyCode = 123;
+        expect(keys.keyboardEventMatchesKeys(event, 'f12')).to.be.equal(true);
+      });
     });
 
     suite('matching keyboard events to top row and number pad digit keys', function() {


### PR DESCRIPTION
In cases when key events for F1-F12 keys don't have a `key` property, but instead just `keyCode`, currently `validKey` is set to values "F0" to "F11"