### PR TITLE
Create IronA11yKeysMixin

### DIFF
--- a/demo/x-key-aware.html
+++ b/demo/x-key-aware.html
@@ -8,8 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../iron-a11y-keys-behavior.html">
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../iron-a11y-keys-mixin.html">
 
 <dom-module id="x-key-aware">
   <template>
@@ -48,49 +48,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-  Polymer({
-    is: 'x-key-aware',
+(function() {
+  'use strict';
+  /** @polymerElement */
+  class XKeyAware extends Polymer.IronA11yKeysMixin(Polymer.Element) {
+    static get is() { return 'x-key-aware'; }
 
-    behaviors: [
-      Polymer.IronA11yKeysBehavior
-    ],
+    static get properties() {
+      return {
+        pressed: {
+          type: String,
+          readOnly: true,
+          value: ''
+        },
 
-    properties: {
-      pressed: {
-        type: String,
-        readOnly: true,
-        value: ''
-      },
+        boundKeys: {
+          type: Array,
+          value: function() {
+            return Object.keys(XKeyAware.keyBindings).join(' ').split(' ');
+          }
+        },
 
-      boundKeys: {
-        type: Array,
-        value: function() {
-          return Object.keys(this.keyBindings).join(' ').split(' ');
+        preventDefault: {
+          type: Boolean,
+          value: true,
+          notify: true
+        },
+
+        keyEventTarget: {
+          type: Object,
+          value: function() {
+            return document.body;
+          }
         }
-      },
+      };
+    }
 
-      preventDefault: {
-        type: Boolean,
-        value: true,
-        notify: true
-      },
+    static get keyBindings() {
+      return {
+        '* pageup pagedown left right down up home end space enter @ ~ " $ ? ! \\ + : # backspace': '_updatePressed',
+        'a': '_updatePressed',
+        'shift+a alt+a': '_updatePressed',
+        'shift+tab shift+space': '_updatePressed'
+      };
+    }
 
-      keyEventTarget: {
-        type: Object,
-        value: function() {
-          return document.body;
-        }
-      }
-    },
-
-    keyBindings: {
-      '* pageup pagedown left right down up home end space enter @ ~ " $ ? ! \\ + : # backspace': '_updatePressed',
-      'a': '_updatePressed',
-      'shift+a alt+a': '_updatePressed',
-      'shift+tab shift+space': '_updatePressed'
-    },
-
-    _updatePressed: function(event) {
+    _updatePressed(event) {
       console.log(event.detail);
 
       if (this.preventDefault) {
@@ -100,5 +103,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.pressed + event.detail.combo + ' pressed!\n'
       );
     }
-  });
+  }
+
+  window.customElements.define(XKeyAware.is, XKeyAware);
+})();
 </script>

--- a/iron-a11y-keys-base.html
+++ b/iron-a11y-keys-base.html
@@ -1,0 +1,425 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer-element.html">
+
+<script>
+  (function() {
+    'use strict';
+
+    /**
+     * Chrome uses an older version of DOM Level 3 Keyboard Events
+     *
+     * Most keys are labeled as text, but some are Unicode codepoints.
+     * Values taken from: http://www.w3.org/TR/2007/WD-DOM-Level-3-Events-20071221/keyset.html#KeySet-Set
+     */
+    var KEY_IDENTIFIER = {
+      'U+0008': 'backspace',
+      'U+0009': 'tab',
+      'U+001B': 'esc',
+      'U+0020': 'space',
+      'U+007F': 'del'
+    };
+
+    /**
+     * Special table for KeyboardEvent.keyCode.
+     * KeyboardEvent.keyIdentifier is better, and KeyBoardEvent.key is even better
+     * than that.
+     *
+     * Values from: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent.keyCode#Value_of_keyCode
+     */
+    var KEY_CODE = {
+      8: 'backspace',
+      9: 'tab',
+      13: 'enter',
+      27: 'esc',
+      33: 'pageup',
+      34: 'pagedown',
+      35: 'end',
+      36: 'home',
+      32: 'space',
+      37: 'left',
+      38: 'up',
+      39: 'right',
+      40: 'down',
+      46: 'del',
+      106: '*'
+    };
+
+    /**
+     * MODIFIER_KEYS maps the short name for modifier keys used in a key
+     * combo string to the property name that references those same keys
+     * in a KeyboardEvent instance.
+     */
+    var MODIFIER_KEYS = {
+      'shift': 'shiftKey',
+      'ctrl': 'ctrlKey',
+      'alt': 'altKey',
+      'meta': 'metaKey'
+    };
+
+    /**
+     * KeyboardEvent.key is mostly represented by printable character made by
+     * the keyboard, with unprintable keys labeled nicely.
+     *
+     * However, on OS X, Alt+char can make a Unicode character that follows an
+     * Apple-specific mapping. In this case, we fall back to .keyCode.
+     */
+    var KEY_CHAR = /[a-z0-9*]/;
+
+    /**
+     * Matches a keyIdentifier string.
+     */
+    var IDENT_CHAR = /U\+/;
+
+    /**
+     * Matches arrow keys in Gecko 27.0+
+     */
+    var ARROW_KEY = /^arrow/;
+
+    /**
+     * Matches space keys everywhere (notably including IE10's exceptional name
+     * `spacebar`).
+     */
+    var SPACE_KEY = /^space(bar)?/;
+
+    /**
+     * Matches ESC key.
+     *
+     * Value from: http://w3c.github.io/uievents-key/#key-Escape
+     */
+    var ESC_KEY = /^escape$/;
+
+    /**
+     * Transforms the key.
+     * @param {string} key The KeyBoardEvent.key
+     * @param {Boolean} [noSpecialChars] Limits the transformation to
+     * alpha-numeric characters.
+     */
+    function transformKey(key, noSpecialChars) {
+      var validKey = '';
+      if (key) {
+        var lKey = key.toLowerCase();
+        if (lKey === ' ' || SPACE_KEY.test(lKey)) {
+          validKey = 'space';
+        } else if (ESC_KEY.test(lKey)) {
+          validKey = 'esc';
+        } else if (lKey.length == 1) {
+          if (!noSpecialChars || KEY_CHAR.test(lKey)) {
+            validKey = lKey;
+          }
+        } else if (ARROW_KEY.test(lKey)) {
+          validKey = lKey.replace('arrow', '');
+        } else if (lKey == 'multiply') {
+          // numpad '*' can map to Multiply on IE/Windows
+          validKey = '*';
+        } else {
+          validKey = lKey;
+        }
+      }
+      return validKey;
+    }
+
+    function transformKeyIdentifier(keyIdent) {
+      var validKey = '';
+      if (keyIdent) {
+        if (keyIdent in KEY_IDENTIFIER) {
+          validKey = KEY_IDENTIFIER[keyIdent];
+        } else if (IDENT_CHAR.test(keyIdent)) {
+          keyIdent = parseInt(keyIdent.replace('U+', '0x'), 16);
+          validKey = String.fromCharCode(keyIdent).toLowerCase();
+        } else {
+          validKey = keyIdent.toLowerCase();
+        }
+      }
+      return validKey;
+    }
+
+    function transformKeyCode(keyCode) {
+      var validKey = '';
+      if (Number(keyCode)) {
+        if (keyCode >= 65 && keyCode <= 90) {
+          // ascii a-z
+          // lowercase is 32 offset from uppercase
+          validKey = String.fromCharCode(32 + keyCode);
+        } else if (keyCode >= 112 && keyCode <= 123) {
+          // function keys f1-f12
+          validKey = 'f' + (keyCode - 112);
+        } else if (keyCode >= 48 && keyCode <= 57) {
+          // top 0-9 keys
+          validKey = String(keyCode - 48);
+        } else if (keyCode >= 96 && keyCode <= 105) {
+          // num pad 0-9
+          validKey = String(keyCode - 96);
+        } else {
+          validKey = KEY_CODE[keyCode];
+        }
+      }
+      return validKey;
+    }
+
+    /**
+      * Calculates the normalized key for a KeyboardEvent.
+      * @param {KeyboardEvent} keyEvent
+      * @param {Boolean} [noSpecialChars] Set to true to limit keyEvent.key
+      * transformation to alpha-numeric chars. This is useful with key
+      * combinations like shift + 2, which on FF for MacOS produces
+      * keyEvent.key = @
+      * To get 2 returned, set noSpecialChars = true
+      * To get @ returned, set noSpecialChars = false
+     */
+    function normalizedKeyForEvent(keyEvent, noSpecialChars) {
+      // Fall back from .key, to .detail.key for artifical keyboard events,
+      // and then to deprecated .keyIdentifier and .keyCode.
+      if (keyEvent.key) {
+        return transformKey(keyEvent.key, noSpecialChars);
+      }
+      if (keyEvent.detail && keyEvent.detail.key) {
+        return transformKey(keyEvent.detail.key, noSpecialChars);
+      }
+      return transformKeyIdentifier(keyEvent.keyIdentifier) ||
+        transformKeyCode(keyEvent.keyCode) || '';
+    }
+
+    function keyComboMatchesEvent(keyCombo, event) {
+      // For combos with modifiers we support only alpha-numeric keys
+      var keyEvent = normalizedKeyForEvent(event, keyCombo.hasModifiers);
+      return keyEvent === keyCombo.key &&
+        (!keyCombo.hasModifiers || (
+          !!event.shiftKey === !!keyCombo.shiftKey &&
+          !!event.ctrlKey === !!keyCombo.ctrlKey &&
+          !!event.altKey === !!keyCombo.altKey &&
+          !!event.metaKey === !!keyCombo.metaKey)
+        );
+    }
+
+    function parseKeyComboString(keyComboString) {
+      if (keyComboString.length === 1) {
+        return {
+          combo: keyComboString,
+          key: keyComboString,
+          event: 'keydown'
+        };
+      }
+      return keyComboString.split('+').reduce(function(parsedKeyCombo, keyComboPart) {
+        var eventParts = keyComboPart.split(':');
+        var keyName = eventParts[0];
+        var event = eventParts[1];
+
+        if (keyName in MODIFIER_KEYS) {
+          parsedKeyCombo[MODIFIER_KEYS[keyName]] = true;
+          parsedKeyCombo.hasModifiers = true;
+        } else {
+          parsedKeyCombo.key = keyName;
+          parsedKeyCombo.event = event || 'keydown';
+        }
+
+        return parsedKeyCombo;
+      }, {
+        combo: keyComboString.split(':').shift()
+      });
+    }
+
+    function parseEventString(eventString) {
+      return eventString.trim().split(' ').map(function(keyComboString) {
+        return parseKeyComboString(keyComboString);
+      });
+    }
+
+    /* Do not use Polymer.dedupingMixin */
+    Polymer.IronA11yKeysBaseMixin = function(superClass) {
+      return class extends superClass {
+        static get properties() {
+          return {
+            /**
+             * The EventTarget that will be firing relevant KeyboardEvents. Set it to
+             * `null` to disable the listeners.
+             * @type {?EventTarget}
+             */
+            keyEventTarget: {
+              type: Object,
+              value: function() {
+                return this;
+              }
+            },
+
+            /**
+             * If true, this property will cause the implementing element to
+             * automatically stop propagation on any handled KeyboardEvents.
+             */
+            stopKeyboardEventPropagation: {
+              type: Boolean,
+              value: false
+            },
+
+            _boundKeyHandlers: {
+              type: Array,
+              value: function() {
+                return [];
+              }
+            },
+
+            // We use this due to a limitation in IE10 where instances will have
+            // own properties of everything on the "prototype".
+            _imperativeKeyBindings: {
+              type: Object,
+              value: function() {
+                return {};
+              }
+            }
+          };
+        }
+
+        static get observers() {
+          return [
+            '_resetKeyEventListeners(keyEventTarget, _boundKeyHandlers)'
+          ];
+        }
+
+        /**
+         * Can be used to imperatively add a key binding to the implementing
+         * element. This is the imperative equivalent of declaring a keybinding
+         * in the `keyBindings` prototype property.
+         */
+        addOwnKeyBinding(eventString, handlerName) {
+          this._imperativeKeyBindings[eventString] = handlerName;
+          this._prepKeyBindings();
+          this._resetKeyEventListeners();
+        }
+
+        /**
+         * When called, will remove all imperatively-added key bindings.
+         */
+        removeOwnKeyBindings() {
+          this._imperativeKeyBindings = {};
+          this._prepKeyBindings();
+          this._resetKeyEventListeners();
+        }
+
+        /**
+         * Returns true if a keyboard event matches `eventString`.
+         *
+         * @param {KeyboardEvent} event
+         * @param {string} eventString
+         * @return {boolean}
+         */
+        keyboardEventMatchesKeys(event, eventString) {
+          var keyCombos = parseEventString(eventString);
+          for (var i = 0; i < keyCombos.length; ++i) {
+            if (keyComboMatchesEvent(keyCombos[i], event)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        _prepKeyBindings() {
+          this._keyBindings = {};
+
+          this._collectKeyBindings().forEach((keyBindings) => {
+            for (var eventString in keyBindings) {
+              this._addKeyBinding(eventString, keyBindings[eventString]);
+            }
+          });
+
+          for (var eventString in this._imperativeKeyBindings) {
+            this._addKeyBinding(eventString, this._imperativeKeyBindings[eventString]);
+          }
+
+          // Give precedence to combos with modifiers to be checked first.
+          for (var eventName in this._keyBindings) {
+            this._keyBindings[eventName].sort(function (kb1, kb2) {
+              var b1 = kb1[0].hasModifiers;
+              var b2 = kb2[0].hasModifiers;
+              return (b1 === b2) ? 0 : b1 ? -1 : 1;
+            })
+          }
+        }
+
+        _addKeyBinding(eventString, handlerName) {
+          parseEventString(eventString).forEach((keyCombo) => {
+            this._keyBindings[keyCombo.event] =
+              this._keyBindings[keyCombo.event] || [];
+
+            this._keyBindings[keyCombo.event].push([ keyCombo, handlerName ]);
+          });
+        }
+
+        _listenKeyEventListeners() {
+          if (!this.keyEventTarget) {
+            return;
+          }
+          Object.keys(this._keyBindings).forEach((eventName) => {
+            var keyBindings = this._keyBindings[eventName];
+            var boundKeyHandler = this._onKeyBindingEvent.bind(this, keyBindings);
+
+            this._boundKeyHandlers.push([this.keyEventTarget, eventName, boundKeyHandler]);
+
+            this.keyEventTarget.addEventListener(eventName, boundKeyHandler);
+          });
+        }
+
+        _unlistenKeyEventListeners() {
+          var keyHandlerTuple;
+          var keyEventTarget;
+          var eventName;
+          var boundKeyHandler;
+
+          while (this._boundKeyHandlers.length) {
+            // My kingdom for block-scope binding and destructuring assignment..
+            keyHandlerTuple = this._boundKeyHandlers.pop();
+            keyEventTarget = keyHandlerTuple[0];
+            eventName = keyHandlerTuple[1];
+            boundKeyHandler = keyHandlerTuple[2];
+
+            keyEventTarget.removeEventListener(eventName, boundKeyHandler);
+          }
+        }
+
+        _onKeyBindingEvent(keyBindings, event) {
+          if (this.stopKeyboardEventPropagation) {
+            event.stopPropagation();
+          }
+
+          // if event has been already prevented, don't do anything
+          if (event.defaultPrevented) {
+            return;
+          }
+
+          for (var i = 0; i < keyBindings.length; i++) {
+            var keyCombo = keyBindings[i][0];
+            var handlerName = keyBindings[i][1];
+            if (keyComboMatchesEvent(keyCombo, event)) {
+              this._triggerKeyHandler(keyCombo, handlerName, event);
+              // exit the loop if eventDefault was prevented
+              if (event.defaultPrevented) {
+                return;
+              }
+            }
+          }
+        }
+
+        _triggerKeyHandler(keyCombo, handlerName, keyboardEvent) {
+          var detail = Object.create(keyCombo);
+          detail.keyboardEvent = keyboardEvent;
+          var event = new CustomEvent(keyCombo.event, {
+            detail: detail,
+            cancelable: true
+          });
+          this[handlerName].call(this, event);
+          if (event.defaultPrevented) {
+            keyboardEvent.preventDefault();
+          }
+        }
+
+      };
+    };
+  })();
+</script>

--- a/iron-a11y-keys-mixin.html
+++ b/iron-a11y-keys-mixin.html
@@ -8,22 +8,20 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="iron-a11y-keys-base.html">
 
 <script>
   (function() {
     'use strict';
 
-    let BaseMixin = Polymer.IronA11yKeysBaseMixin(Object);
-
     /**
-     * `Polymer.IronA11yKeysBehavior` provides a normalized interface for processing
+     * `Polymer.IronA11yKeysMixin` provides a normalized interface for processing
      * keyboard commands that pertain to [WAI-ARIA best practices](http://www.w3.org/TR/wai-aria-practices/#kbd_general_binding).
      * The element takes care of browser differences with respect to Keyboard events
      * and uses an expressive syntax to filter key presses.
      *
-     * Use the `keyBindings` prototype property to express what combination of keys
+     * Use the `keyBindings` static property to express what combination of keys
      * will trigger the callback. A key binding has the format
      * `"KEY+MODIFIER:EVENT": "callback"` (`"KEY": "callback"` or
      * `"KEY:EVENT": "callback"` are valid as well). Some examples:
@@ -51,57 +49,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * for an example.
      *
      * @demo demo/index.html
-     * @polymerBehavior
+     * @polymerMixin
      */
-    Polymer.IronA11yKeysBehavior = {
-      properties: BaseMixin.properties,
-      observers: BaseMixin.observers,
-
-      /**
-       * To be used to express what combination of keys  will trigger the relative
-       * callback. e.g. `keyBindings: { 'esc': '_onEscPressed'}`
-       * @type {!Object}
-       */
-      keyBindings: {},
-
-      registered: function() {
-        this._prepKeyBindings();
-      },
-
-      attached: function() {
-        this._listenKeyEventListeners();
-      },
-
-      detached: function() {
-        this._unlistenKeyEventListeners();
-      },
-
-      _collectKeyBindings: function() {
-        var keyBindings = this.behaviors.map(function(behavior) {
-          return behavior.keyBindings;
-        });
-
-        if (keyBindings.indexOf(this.keyBindings) === -1) {
-          keyBindings.push(this.keyBindings);
+    Polymer.IronA11yKeysMixin = Polymer.dedupingMixin(function(superClass) {
+      return class extends Polymer.IronA11yKeysBaseMixin(superClass) {
+        static get properties() {
+          return {
+            _keyBindingsConnected: {
+              type: Boolean,
+              value: false
+            }
+          };
         }
 
-        return keyBindings;
-      },
+        constructor() {
+          super();
+          this._prepKeyBindings();
+        }
 
-      _resetKeyEventListeners: function() {
-        this._unlistenKeyEventListeners();
-
-        if (this.isAttached) {
+        connectedCallback() {
+          super.connectedCallback();
+          this._keyBindingsConnected = true;
           this._listenKeyEventListeners();
         }
-      }
-    };
 
-    /* Copy methods from BaseMixin prototype. */
-    Object.getOwnPropertyNames(BaseMixin.prototype).forEach((key) => {
-      if (key != 'constructor') {
-        Polymer.IronA11yKeysBehavior[key] = BaseMixin.prototype[key];
-      }
+        disconnectedCallback() {
+          super.disconnectedCallback();
+          this._keyBindingsConnected = false;
+          this._unlistenKeyEventListeners();
+        }
+
+        _collectKeyBindings() {
+          let keyBindings = [];
+          let proto = Object.getPrototypeOf(this);
+
+          while (proto) {
+            let ctor = proto.constructor;
+            if (!ctor.prototype instanceof HTMLElement) {
+              break;
+            }
+            proto = Object.getPrototypeOf(ctor.prototype);
+
+            if (ctor.hasOwnProperty('keyBindings')) {
+              keyBindings.unshift(ctor.keyBindings);
+            }
+          }
+
+          return keyBindings;
+        }
+
+        _resetKeyEventListeners() {
+          this._unlistenKeyEventListeners();
+
+          if (this._keyBindingsConnected) {
+            this._listenKeyEventListeners();
+          }
+        }
+
+      };
     });
   })();
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -19,7 +19,9 @@
       // Load and run all tests (.html, .js) as one suite:
       WCT.loadSuites([
         'basic-test.html?wc-shadydom=true&wc-ce=true', //shady
-        'basic-test.html?dom=shadow' //shadow
+        'basic-test.html?dom=shadow', //shadow
+        'mixin-test.html?wc-shadydom=true&wc-ce=true', //shady
+        'mixin-test.html?dom=shadow' //shadow
       ]);
     </script>
 

--- a/test/mixin-test.html
+++ b/test/mixin-test.html
@@ -1,0 +1,454 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>iron-a11y-keys</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+  <!-- Something in mock-interactions seems to require more than polymer-element.html  -->
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../iron-a11y-keys-mixin.html">
+</head>
+<body>
+  <test-fixture id="BasicKeys">
+    <template>
+      <x-a11y-basic-keys></x-a11y-basic-keys>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="NonPropagatingKeys">
+    <template>
+      <x-a11y-basic-keys stop-keyboard-event-propagation></x-a11y-basic-keys>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="ComboKeys">
+    <template>
+      <x-a11y-combo-keys></x-a11y-combo-keys>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="AlternativeEventKeys">
+    <template>
+      <x-a11y-alternate-event-keys></x-a11y-alternate-event-keys>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="MixinKeys">
+    <template>
+      <x-a11y-mixin-keys></x-a11y-mixin-keys>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="PreventKeys">
+    <template>
+      <x-a11y-prevent-keys></x-a11y-prevent-keys>
+    </template>
+  </test-fixture>
+
+  <script>
+suite('Polymer.IronA11yKeysMixin', function() {
+  var keys;
+
+  suiteSetup(function() {
+    /** @polymerMixin */
+    function KeysTestMixin(superClass) {
+      return class extends Polymer.IronA11yKeysMixin(superClass) {
+        static get properties() {
+          return {
+            keyCount: {
+              type: Number,
+              value: 0
+            }
+          }
+        }
+
+        _keyHandler(event) {
+          this.keyCount++;
+          this.lastEvent = event;
+        }
+
+        // Same as _keyHandler, used to distinguish who's called before who.
+        _keyHandler2(event) {
+          this.keyCount++;
+          this.lastEvent = event;
+        }
+
+        _preventDefaultHandler(event) {
+          event.preventDefault();
+          this.keyCount++;
+          this.lastEvent = event;
+        }
+      };
+    }
+
+    /** @polymerElement */
+    class XA11yBasicKeys extends KeysTestMixin(Polymer.Element) {
+      static get is() { return 'x-a11y-basic-keys'; }
+      static get keyBindings() {
+        return {
+          'space': '_keyHandler',
+          '@': '_keyHandler',
+          'esc': '_keyHandler'
+        }
+      }
+    }
+
+    /** @polymerElement */
+    class XA11yComboKeys extends KeysTestMixin(Polymer.Element) {
+      static get is() { return 'x-a11y-combo-keys'; }
+      static get keyBindings() {
+        return {
+          'enter': '_keyHandler2',
+          'ctrl+shift+a shift+enter': '_keyHandler'
+        };
+      }
+    };
+
+    /** @polymerElement */
+    class XA11yAlternateEventKeys extends KeysTestMixin(Polymer.Element) {
+      static get is() { return 'x-a11y-alternate-event-keys'; }
+      static get keyBindings() {
+        return {
+          'space:keyup': '_keyHandler'
+        };
+      }
+    };
+
+    /** @polymerMixin */
+    function XA11yMixin(superClass) {
+      return class extends superClass {
+        static get keyBindings() {
+          return {
+            'enter': '_keyHandler'
+          };
+        }
+      }
+    }
+
+    /** @polymerElement */
+    class XA11yMixinKeys extends XA11yMixin(KeysTestMixin(Polymer.Element)) {
+      static get is() { return 'x-a11y-mixin-keys'; }
+      static get keyBindings() {
+        return {
+          'enter': '_keyHandler'
+        };
+      }
+    }
+
+    /** @polymerElement */
+    class XA11yPreventKeys extends XA11yMixin(KeysTestMixin(Polymer.Element)) {
+      static get is() { return 'x-a11y-prevent-keys'; }
+      static get keyBindings() {
+        return {
+          'space a': '_keyHandler',
+          'enter shift+a': '_preventDefaultHandler'
+        };
+      }
+    }
+
+    [
+      XA11yBasicKeys,
+      XA11yComboKeys,
+      XA11yAlternateEventKeys,
+      XA11yMixinKeys,
+      XA11yPreventKeys
+    ].forEach((proto) => {
+      window.customElements.define(proto.is, proto);
+    });
+  });
+
+  suite('basic keys', function() {
+    setup(function() {
+      keys = fixture('BasicKeys');
+    });
+
+    test('trigger the handler when the specified key is pressed', function() {
+      MockInteractions.pressSpace(keys);
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('keyEventTarget can be null, and disables listeners', function() {
+      keys.keyEventTarget = null;
+      MockInteractions.pressSpace(keys);
+
+      expect(keys.keyCount).to.be.equal(0);
+    });
+
+    test('trigger the handler when the specified key is pressed together with a modifier', function() {
+      var event = new CustomEvent('keydown');
+      event.ctrlKey = true;
+      event.keyCode = event.code = 32;
+      keys.dispatchEvent(event);
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('handles special character @', function() {
+      MockInteractions.pressAndReleaseKeyOn(keys, undefined, [], '@');
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('handles variations of Esc key', function() {
+      MockInteractions.pressAndReleaseKeyOn(keys, undefined, [], 'Esc');
+      expect(keys.keyCount).to.be.equal(1);
+
+      MockInteractions.pressAndReleaseKeyOn(keys, undefined, [], 'Escape');
+      expect(keys.keyCount).to.be.equal(2);
+
+      MockInteractions.pressAndReleaseKeyOn(keys, 27, [], '');
+      expect(keys.keyCount).to.be.equal(3);
+    });
+
+    test('do not trigger the handler for non-specified keys', function() {
+      MockInteractions.pressEnter(keys);
+
+      expect(keys.keyCount).to.be.equal(0);
+    });
+
+    test('can have bindings added imperatively', function() {
+      keys.addOwnKeyBinding('enter', '_keyHandler');
+
+      MockInteractions.pressEnter(keys);
+      expect(keys.keyCount).to.be.equal(1);
+
+      MockInteractions.pressSpace(keys);
+      expect(keys.keyCount).to.be.equal(2);
+    });
+
+    test('can remove imperatively added bindings', function() {
+      keys.addOwnKeyBinding('enter', '_keyHandler');
+      keys.removeOwnKeyBindings();
+
+      MockInteractions.pressEnter(keys);
+      expect(keys.keyCount).to.be.equal(0);
+
+      MockInteractions.pressSpace(keys);
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('allows propagation beyond the key combo handler', function() {
+      var keySpy = sinon.spy();
+      document.addEventListener('keydown', keySpy);
+
+      MockInteractions.pressEnter(keys);
+
+      expect(keySpy.callCount).to.be.equal(1);
+    });
+
+    suite('edge cases', function() {
+      test('knows that `spacebar` is the same as `space`', function() {
+        var event = new CustomEvent('keydown');
+        event.key = 'spacebar';
+        expect(keys.keyboardEventMatchesKeys(event, 'space')).to.be.equal(true);
+      });
+
+      test('handles `+`', function() {
+        var event = new CustomEvent('keydown');
+        event.key = '+';
+        expect(keys.keyboardEventMatchesKeys(event, '+')).to.be.equal(true);
+      });
+
+      test('handles `:`', function() {
+        var event = new CustomEvent('keydown');
+        event.key = ':';
+        expect(keys.keyboardEventMatchesKeys(event, ':')).to.be.equal(true);
+      });
+
+      test('handles ` ` (space)', function() {
+        var event = new CustomEvent('keydown');
+        event.key = ' ';
+        expect(keys.keyboardEventMatchesKeys(event, 'space')).to.be.equal(true);
+      });
+    });
+
+    suite('matching keyboard events to keys', function() {
+      test('can be done imperatively', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 65;
+        expect(keys.keyboardEventMatchesKeys(event, 'a')).to.be.equal(true);
+      });
+
+      test('can be done with a provided keyboardEvent', function() {
+        var event;
+        MockInteractions.pressSpace(keys);
+        event = keys.lastEvent;
+
+        expect(event.detail.keyboardEvent).to.be.okay;
+        expect(keys.keyboardEventMatchesKeys(event, 'space')).to.be.equal(true);
+      });
+
+      test('can handle variations in arrow key names', function() {
+        var event = new CustomEvent('keydown');
+        event.key = 'up';
+        expect(keys.keyboardEventMatchesKeys(event, 'up')).to.be.equal(true);
+        event.key = 'ArrowUp';
+        expect(keys.keyboardEventMatchesKeys(event, 'up')).to.be.equal(true);
+      });
+    });
+
+    suite('matching keyboard events to top row and number pad digit keys', function() {
+      test('top row can be done imperatively', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 49;
+        expect(keys.keyboardEventMatchesKeys(event, '1')).to.be.equal(true);
+      });
+
+      test('number pad digits can be done imperatively', function() {
+        var event = new CustomEvent('keydown');
+        event.keyCode = 97;
+        expect(keys.keyboardEventMatchesKeys(event, '1')).to.be.equal(true);
+      });
+    });
+  });
+
+  suite('combo keys', function() {
+    setup(function() {
+      keys = fixture('ComboKeys');
+    });
+
+    test('trigger the handler when the combo is pressed', function() {
+      var event = new CustomEvent('keydown');
+
+      event.ctrlKey = true;
+      event.shiftKey = true;
+      event.keyCode = event.code = 65;
+
+      keys.dispatchEvent(event);
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('check if KeyBoardEvent.key is alpha-numberic', function() {
+      var event = new CustomEvent('keydown');
+
+      event.ctrlKey = true;
+      event.shiftKey = true;
+      event.key = 'A';
+
+      keys.dispatchEvent(event);
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+
+    test('trigger also bindings without modifiers', function() {
+      var event = new CustomEvent('keydown');
+      // Combo `shift+enter`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 13;
+      keys.dispatchEvent(event);
+      expect(keys.keyCount).to.be.equal(2);
+    });
+
+    test('give precendence to combos with modifiers', function() {
+      var enterSpy = sinon.spy(keys, '_keyHandler2');
+      var shiftEnterSpy = sinon.spy(keys, '_keyHandler');
+      var event = new CustomEvent('keydown');
+      // Combo `shift+enter`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 13;
+      keys.dispatchEvent(event);
+      expect(enterSpy.called).to.be.true;
+      expect(shiftEnterSpy.called).to.be.true;
+      expect(enterSpy.calledAfter(shiftEnterSpy)).to.be.true;
+    });
+
+  });
+
+  suite('alternative event keys', function() {
+    setup(function() {
+      keys = fixture('AlternativeEventKeys');
+    });
+
+    test('trigger on the specified alternative keyboard event', function() {
+      MockInteractions.keyDownOn(keys, 32);
+
+      expect(keys.keyCount).to.be.equal(0);
+
+      MockInteractions.keyUpOn(keys, 32);
+
+      expect(keys.keyCount).to.be.equal(1);
+    });
+  });
+
+  suite('mixin keys', function() {
+    setup(function() {
+      keys = fixture('MixinKeys');
+    });
+
+    test('bindings in other mixins are transitive', function() {
+      MockInteractions.pressEnter(keys);
+      expect(keys.keyCount).to.be.equal(2);
+    });
+  });
+
+  suite('stopping propagation automatically', function() {
+    setup(function() {
+      keys = fixture('NonPropagatingKeys');
+    });
+
+    test('does not propagate key events beyond the combo handler', function() {
+      var keySpy = sinon.spy();
+
+      document.addEventListener('keydown', keySpy);
+
+      MockInteractions.pressEnter(keys);
+
+      expect(keySpy.callCount).to.be.equal(0);
+    });
+  });
+
+  suite('prevent default mixin of event', function() {
+    setup(function() {
+      keys = fixture('PreventKeys');
+    });
+
+    test('`defaultPrevented` is correctly set', function() {
+      MockInteractions.pressEnter(keys);
+      expect(keys.lastEvent.defaultPrevented).to.be.equal(true);
+    });
+
+    test('only 1 handler is invoked', function() {
+      var aSpy = sinon.spy(keys, '_keyHandler');
+      var shiftASpy = sinon.spy(keys, '_preventDefaultHandler');
+      var event = new CustomEvent('keydown', {
+        cancelable: true
+      });
+      // Combo `shift+a`.
+      event.shiftKey = true;
+      event.keyCode = event.code = 65;
+      keys.dispatchEvent(event);
+
+      expect(keys.keyCount).to.be.equal(1);
+      expect(shiftASpy.called).to.be.true;
+      expect(aSpy.called).to.be.false;
+    });
+  });
+
+  suite('remove key mixin with null target', function () {
+    test('add and remove a iron-a11y-keys-mixin', function () {
+      var element = document.createElement('x-a11y-basic-keys');
+      element.keyEventTarget = null;
+      document.body.appendChild(element);
+      document.body.removeChild(element);
+    });
+  });
+
+});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This creates a mixin that implements key bindings for non-legacy Polymer
2.0 elements.  The mixin does not look at the keyBindings property of
behaviors, all keyBindings must be declared as a static property of a
class in the hierarchy.

A new test has been created to check the mixin based key bindings.  All
tests passed on Chrome 57 and Firefox 52 under Fedora 25.  travis-ci
will likely fail due to use of variants.

I'm open to suggestions about better ways to organize the code.  Organization had the following priorities:
* Non-breaking change for users of the behavior.
* Do not directly or indirectly import any legacy code for users of the mixin.
* Avoid code duplication to minimize download size if some elements use mixin and others behavior.