### PR TITLE
No longer leads to an error in combination with `disable-upgrade`.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-a11y-keys-behavior",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "A behavior that enables keybindings for greater a11y.",
   "keywords": [
     "web-components",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-a11y-keys-behavior",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "A behavior that enables keybindings for greater a11y.",
   "keywords": [
     "web-components",

--- a/iron-a11y-keys-behavior.html
+++ b/iron-a11y-keys-behavior.html
@@ -445,7 +445,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var eventName;
         var boundKeyHandler;
 
-        while (this._boundKeyHandlers.length) {
+        while (this._boundKeyHandlers && this._boundKeyHandlers.length) {
           // My kingdom for block-scope binding and destructuring assignment..
           keyHandlerTuple = this._boundKeyHandlers.pop();
           keyEventTarget = keyHandlerTuple[0];


### PR DESCRIPTION
Fixes an issue where an element with this behavior and `disable-upgrade` throws an error when the element gets `detached`.